### PR TITLE
Update the version of the BlazorWasmPreRendering.Build

### DIFF
--- a/Example.PrerenderingWithWorkers.csproj
+++ b/Example.PrerenderingWithWorkers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorWasmPreRendering.Build" Version="3.1.0-preview.3" />
+    <PackageReference Include="BlazorWasmPreRendering.Build" Version="3.1.0-preview.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0-rc.1.23421.29" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0-rc.1.23421.29" PrivateAssets="all" />
     <PackageReference Include="SpawnDev.BlazorJS.WebWorkers" Version="2.2.8" />


### PR DESCRIPTION
This pull request will fix the problem that the helper script will crash when it runs in a web worker.